### PR TITLE
add Dockerfile. deploy docker alpine+git+clone repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM alpine
+MAINTAINER arefevoa
+
+RUN	apk add git
+RUN 	mkdir /home/gittest/ && cd /home/gittest/ && git clone https://github.com/arefevoa/test-repo.git
+RUN	ls 
+
+CMD ["top"]


### PR DESCRIPTION
почему в докерфайле прописана последняя команда ls ?
для проверки при билде - удостовериться, что не в корень склонировало

почему в CMD прописан top?
если стартануть не в бэкграунде - то можно посмотреть загрузку цпу - исключительно для тестов прописано

выхлоп консоли

собираем контейнер по докерфайлу в текущей директории:

MacBook:test-repo admin$ docker build -t testalpine .
Sending build context to Docker daemon    108kB
Step 1/6 : FROM alpine
 ---> 961769676411
Step 2/6 : MAINTAINER arefevoa
 ---> Using cache
 ---> ba1094d5fba7
Step 3/6 : RUN	apk add git
 ---> Using cache
 ---> 9210468c87a5
Step 4/6 : RUN 	mkdir /home/gittest/ && cd /home/gittest/ && git clone https://github.com/arefevoa/test-repo.git
 ---> Running in 240d364c0bd4
Cloning into 'test-repo'...
Removing intermediate container 240d364c0bd4
 ---> 1f90a3fb542a
Step 5/6 : RUN	ls
 ---> Running in 6d35dce94ccf
bin
dev
etc
home
lib
media
mnt
opt
proc
root
run
sbin
srv
sys
tmp
usr
var
Removing intermediate container 6d35dce94ccf
 ---> 5e3c5b1e68d7
Step 6/6 : CMD ["top"]
 ---> Running in 0ffb4bf3febd
Removing intermediate container 0ffb4bf3febd
 ---> 3414a7eaba1d
Successfully built 3414a7eaba1d
Successfully tagged testalpine:latest

стартуем контейнер в фоне

MacBook:test-repo admin$ docker run -d 3414a7eaba1d
893a8823afc9432600e47376793f8d4ac24093c8a513f243a306924f2d056d2f


подключаемся к контейнеру 
MacBook:test-repo admin$ docker exec -ti 893a8823afc9432600e47376793f8d4ac24093c8a513f243a306924f2d056d2f sh
